### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains a Model Context Protocol (MCP) server that provides Claude with access to Ethereum and EVM-compatible blockchain operations via ethers.js v5. The server enables Claude to perform operations like creating wallets, checking balances, sending transactions, and interacting with smart contracts on EVM-compatible blockchains.
 
+<a href="https://glama.ai/mcp/servers/@dcSpark/mcp-cryptowallet-evm">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@dcSpark/mcp-cryptowallet-evm/badge" alt="Crypto Wallet EVM MCP server" />
+</a>
+
 ## Overview
 
 The MCP server exposes the following tools to Claude:


### PR DESCRIPTION
This PR adds a badge for the [MCP Crypto Wallet EVM](https://glama.ai/mcp/servers/@dcSpark/mcp-cryptowallet-evm) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@dcSpark/mcp-cryptowallet-evm">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@dcSpark/mcp-cryptowallet-evm/badge" alt="Crypto Wallet EVM MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.